### PR TITLE
[TECH] Abaisse le niveau d'assurance du wording dans le template de PR

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 ## :unicorn: Problème
 > _Décrivez ici le besoin ou l'intention couvert par cette Pull Request._
 
-## :robot: Solution
+## :robot: Proposition
 > _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._
 
 ## :rainbow: Remarques


### PR DESCRIPTION
## :christmas_tree: Problème
Le wording utilisé dans nos templates de PR laisse entendre que la solution choisie est unique et définitive.

## :gift: Proposition
Suivant les recommandations de [cet article sur l'Egoless programming](https://blog.octo.com/egoless-programming/), ce nouveau wording me parait moins sûr de lui.

## :star2: Remarques
Déjà mis en oeuvre sur [1024pix/pix](https://github.com/1024pix/pix/pull/5034).

## :santa: Pour tester
N/A
