### PR TITLE
Ajoute la GitHub Action d'automerge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,23 @@
+name: automerge check
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+  check_suite:
+    types:
+      - completed
+  status:
+    types:
+      - success
+
+permissions: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1024pix/pix-actions/auto-merge@v0
+        with:
+          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :christmas_tree: Problème
Pour faciliter les mises à jour, on utilise une GitHub Action qui permet de rebase puis de merger dès que les tests passent.

## :gift: Proposition
Ajouter cette GA au projet template.

## :star2: Remarques
Le token `PIX_SERVICE_ACTIONS_TOKEN` n'a pas encore été ajouté.

## :santa: Pour tester
Vérifier que cette PR soit mergée une fois le tag ":rocket: Ready to merge" ajouté.
